### PR TITLE
Fix line continuation when comma/backslash is followed by whitespace

### DIFF
--- a/lib/slimi/parser.rb
+++ b/lib/slimi/parser.rb
@@ -547,7 +547,7 @@ module Slimi
     def parse_broken_lines
       result = +''
       result << @scanner.scan(/[^\r\n]*/)
-      while result.end_with?(',') || result.end_with?('\\')
+      while result.rstrip.end_with?(',') || result.rstrip.end_with?('\\')
         syntax_error!(Errors::UnexpectedEosError) unless @scanner.scan(/\r?\n/)
 
         result << "\n"

--- a/spec/slimi/parser_spec.rb
+++ b/spec/slimi/parser_spec.rb
@@ -97,6 +97,21 @@ RSpec.describe Slimi::Parser do
       end
     end
 
+    context 'with output code with comma followed by space for line continuation' do
+      let(:source) do
+        <<~SLIM
+          = label_tag :label, 
+            "Label"
+        SLIM
+      end
+
+      it 'returns expected s-expression' do
+        is_expected.to eq(
+                         [:multi, [:slimi, :position, 2, 30, [:slimi, :output, true, "label_tag :label, \n  \"Label\"", [:multi, [:newline]]]]]
+                       )
+      end
+    end
+
     context 'with HTML comment' do
       let(:source) do
         <<~SLIM

--- a/spec/slimi/parser_spec.rb
+++ b/spec/slimi/parser_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Slimi::Parser do
       end
     end
 
-    # rubocop:disable Layout/TrailingWhitespace, Layout/FirstArgumentIndentation
+    # rubocop:disable Layout/TrailingWhitespace
     context 'with output code with comma followed by space for line continuation' do
       let(:source) do
         <<~SLIM
@@ -108,11 +108,11 @@ RSpec.describe Slimi::Parser do
 
       it 'returns expected s-expression' do
         is_expected.to eq(
-                         [:multi, [:slimi, :position, 2, 30, [:slimi, :output, true, "label_tag :label, \n  \"Label\"", [:multi, [:newline]]]]]
-                       )
+          [:multi, [:slimi, :position, 2, 30, [:slimi, :output, true, "label_tag :label, \n  \"Label\"", [:multi, [:newline]]]]]
+        )
       end
     end
-    # rubocop:enable Layout/TrailingWhitespace, Layout/FirstArgumentIndentation
+    # rubocop:enable Layout/TrailingWhitespace
 
     context 'with HTML comment' do
       let(:source) do

--- a/spec/slimi/parser_spec.rb
+++ b/spec/slimi/parser_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe Slimi::Parser do
       end
     end
 
+    # rubocop:disable Layout/TrailingWhitespace, Layout/FirstArgumentIndentation
     context 'with output code with comma followed by space for line continuation' do
       let(:source) do
         <<~SLIM
@@ -111,6 +112,7 @@ RSpec.describe Slimi::Parser do
                        )
       end
     end
+    # rubocop:enable Layout/TrailingWhitespace, Layout/FirstArgumentIndentation
 
     context 'with HTML comment' do
       let(:source) do


### PR DESCRIPTION
Previously, the parser would not recognize a line continuation if there were spaces after the comma or backslash. This patch ensures that trailing whitespace is ignored when checking for continuation characters.