### PR TITLE
Fix infinite loop when parsing Ruby attribute values without trailing newline

### DIFF
--- a/lib/slimi/parser.rb
+++ b/lib/slimi/parser.rb
@@ -320,9 +320,10 @@ module Slimi
             opening_delimiter = @scanner.matched
             closing_delimiter = @ruby_attribute_delimiters[opening_delimiter]
           end
-          if (character = @scanner.scan(/[^\r\n]/))
-            attribute_value << character
-          end
+          character = @scanner.scan(/[^\r\n]/)
+          break unless character
+
+          attribute_value << character
         end
       end
       syntax_error!(Errors::RubyAttributeClosingDelimiterNotFoundError) if count != 0

--- a/spec/slimi/parser_spec.rb
+++ b/spec/slimi/parser_spec.rb
@@ -271,6 +271,18 @@ RSpec.describe Slimi::Parser do
       end
     end
 
+    context 'with Ruby attribute without trailing newline' do
+      let(:source) do
+        'div class=a'
+      end
+
+      it 'returns expected s-expression' do
+        is_expected.to eq(
+          [:multi, [:html, :tag, 'div', [:html, :attrs, [:html, :attr, 'class', [:slimi, :position, 10, 11, [:slimi, :attrvalue, true, 'a']]]], [:multi]]]
+        )
+      end
+    end
+
     context 'with Ruby attribute with parentheses' do
       let(:source) do
         <<~SLIM


### PR DESCRIPTION
Hi.
My project uses rubocop-slim. I found an issue where rubocop execution does not complete when there is no newline at the end of the file and the file ends with a Ruby attribute value.
Since root cause was slimi entering an infinite loop, I have fixed in this PR.

```slim
div class=a
```

reproducible script:

```ruby
# frozen_string_literal: true

require 'bundler/inline'
require 'timeout'

gemfile do
  source 'https://rubygems.org'
  gem 'slimi'
end

source = 'div class=a'

begin
  Timeout.timeout(5) do
    parser = Slimi::Parser.new
    parser.call(source)
    puts "✓ Parsed successfully"
  end
rescue Timeout::Error
  puts "✗ Timeout (slimi #{Slimi::VERSION})"
  exit 1
end
```

```
$ ruby reproduce_infinite_loop.rb
✗ Timeout (slimi 0.7.6)
```

I confirmed that combining the PR fix with rubocop-slim successfully parses actual files without error.

```
$ bundle exec rubocop index.html.slim
Inspecting 1 file
.

1 file inspected, no offenses detected
```

```
$ cat Gemfile
# frozen_string_literal: true

source 'https://rubygems.org'

gem 'rubocop'
gem 'rubocop-slim'
gem 'slimi', git: 'https://github.com/ytjmt/slimi', branch: 'fix-infinite-loop'
```

```
$ cat .rubocop.yml
plugins:
  - rubocop-slim

AllCops:
  NewCops: enable
```

```
$ cat index.html.slim
div class=a%        
```

`%` means no trailing newline at the end of the file. `div class=a` is the actual text.
If I comment out `gem 'slimi', git: 'https://github.com/ytjmt/slimi', branch: 'fix-infinite-loop'`, rubocop execution does not complete 