### PR TITLE
Change required ruby version from 2.6+ to 3.3+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,25 @@
 name: test
 
 on:
-  pull_request:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "3.3"
+          - ruby
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ruby
+        ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - run: bundle exec rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,6 @@ require:
 AllCops:
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 2.6
 
 Layout/LineLength:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Change required Ruby version to 3.3 or later.
+
 ## 0.8.0 - 2026-06-13
 
 - Support splat attributes.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,22 +9,25 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionview (7.1.3.4)
-      activesupport (= 7.1.3.4)
+    actionview (8.1.3)
+      activesupport (= 8.1.3)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activesupport (7.1.3.4)
+    activesupport (8.1.3)
       base64
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
@@ -39,17 +42,20 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    logger (1.7.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    minitest (5.24.1)
-    mutex_m (0.2.0)
-    nokogiri (1.18.10-x86_64-linux-gnu)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.25.1)
     parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
+    prism (1.9.0)
     racc (1.8.0)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
@@ -92,6 +98,7 @@ GEM
     rubocop-rspec (3.0.3)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
     strscan (3.1.0)
     temple (0.10.3)
     thor (1.3.2)
@@ -99,6 +106,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uri (1.1.1)
 
 PLATFORMS
   x86_64-linux

--- a/lib/slimi/filters/do_inserter.rb
+++ b/lib/slimi/filters/do_inserter.rb
@@ -4,7 +4,7 @@ module Slimi
   module Filters
     # Append missing `do` to embedded Ruby code.
     class DoInserter < Base
-      VALID_RUBY_LINE_REGEXP = /(\A(if|unless|else|elsif|when|begin|rescue|ensure|case)\b)|\bdo\s*(\|[^|]*\|\s*)?\Z/.freeze
+      VALID_RUBY_LINE_REGEXP = /(\A(if|unless|else|elsif|when|begin|rescue|ensure|case)\b)|\bdo\s*(\|[^|]*\|\s*)?\Z/
 
       # @param [String] code
       # @param [Array] expressio

--- a/lib/slimi/filters/end_inserter.rb
+++ b/lib/slimi/filters/end_inserter.rb
@@ -36,11 +36,11 @@ module Slimi
       end
 
       class Expression
-        IF_REGEXP = /\A(if|begin|unless|else|elsif|when|rescue|ensure)\b|\bdo\s*(\|[^|]*\|)?\s*$/.freeze
+        IF_REGEXP = /\A(if|begin|unless|else|elsif|when|rescue|ensure)\b|\bdo\s*(\|[^|]*\|)?\s*$/
 
-        ELSE_REGEXP = /\A(else|elsif|when|rescue|ensure)\b/.freeze
+        ELSE_REGEXP = /\A(else|elsif|when|rescue|ensure)\b/
 
-        END_REGEXP = /\Aend\b/.freeze
+        END_REGEXP = /\Aend\b/
 
         # @param [Array] expression
         def initialize(expression)

--- a/lib/slimi/filters/output.rb
+++ b/lib/slimi/filters/output.rb
@@ -6,7 +6,7 @@ module Slimi
     class Output < Base
       define_options :disable_capture
 
-      IF_REGEXP = /\A(if|unless)\b|\bdo\s*(\|[^|]*\|)?\s*$/.freeze
+      IF_REGEXP = /\A(if|unless)\b|\bdo\s*(\|[^|]*\|)?\s*$/
 
       # @param [Boolean] escape
       # @param [String] code

--- a/lib/slimi/filters/splat.rb
+++ b/lib/slimi/filters/splat.rb
@@ -77,7 +77,7 @@ module Slimi
 
       class Builder
         # https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
-        INVALID_ATTRIBUTE_NAME_REGEXP = %r{[ \0"'>/=]}.freeze
+        INVALID_ATTRIBUTE_NAME_REGEXP = %r{[ \0"'>/=]}
 
         # @param [Hash] options
         def initialize(options)

--- a/lib/slimi/rails_template_handler.rb
+++ b/lib/slimi/rails_template_handler.rb
@@ -8,8 +8,8 @@ module Slimi
     # @return [String]
     def call(template, source = nil)
       Renderer.new(
-        source: source,
-        template: template
+        source:,
+        template:
       ).call
     end
 

--- a/slimi.gemspec
+++ b/slimi.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Yet another implementation for Slim template language.'
   spec.homepage      = 'https://github.com/r7kamura/slimi'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.3'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage

--- a/spec/slimi/rails_template_handler_spec.rb
+++ b/spec/slimi/rails_template_handler_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Slimi::RailsTemplateHandler do
         source,
         identifier,
         handler,
-        format: format,
+        format:,
         locals: {}
       )
     end


### PR DESCRIPTION
By ending support for versions that have already reached EOL, we will make future maintenance easier.